### PR TITLE
fix: dead RAG buttons, embedding loss on chunk edit, failing pack installs, and dead card renderer

### DIFF
--- a/baby-bunny-mode.js
+++ b/baby-bunny-mode.js
@@ -24,12 +24,12 @@
 
 import { saveSettingsDebounced, chat, chat_metadata, characters, this_chid } from '../../../../script.js';
 import { extension_settings, getContext, saveMetadataDebounced } from '../../../extensions.js';
-import { parseRegexFromString, world_info, world_names, loadWorldInfo, createWorldInfoEntry, saveWorldInfo, updateWorldInfoList, selected_world_info } from '../../../world-info.js';
+import { parseRegexFromString, world_info, world_names, loadWorldInfo, createNewWorldInfo, createWorldInfoEntry, saveWorldInfo, updateWorldInfoList, selected_world_info } from '../../../world-info.js';
 import { highlightRegex } from '../../../utils.js';
 import { regenerateChunkKeywords, detectFullsheetInMessage, vectorizeFullsheetFromMessage, chunkFullsheet } from './fullsheet-rag.js';
 import { CarrotDebug } from './debugger.js';
 import { closeTutorial } from './tutorials.js';
-import { EXTENSION_NAME } from './carrot-state.js';
+import { EXTENSION_NAME, characterRepoBooks } from './carrot-state.js';
 
 const extensionName = EXTENSION_NAME;
 const CUSTOM_KEYWORD_PRIORITY = 100; // Default weight for custom keywords
@@ -1286,21 +1286,21 @@ async function showBatchBabyBunnyPopup(charactersData) {
 
             CarrotDebug.ui('🐰 BATCH: Processing', characterConfigs.length, 'enabled characters');
 
-            overlay.remove();
+            // Validate all inputs BEFORE tearing down the popup. Destroying it first
+            // (as before) meant any validation failure discarded the user's entire
+            // configuration with no way to recover, and left the returned promise
+            // permanently unresolved since resolve() was never called on these paths.
+            let singleLorebookName = null;
+            const multipleLorebookNames = [];
 
-            // Process based on mode
             if (mode === 'single-new') {
-                const lorebookName = popup.find('#batch-lorebook-name').val().trim();
-                if (!lorebookName) {
+                singleLorebookName = popup.find('#batch-lorebook-name').val().trim();
+                if (!singleLorebookName) {
                     toastr.error('Please enter a lorebook name');
+                    resolve(false);
                     return;
                 }
-
-                // Create single lorebook for all characters
-                await processBatchToSingleLorebook(characterConfigs, lorebookName, true, scope);
-
             } else if (mode === 'multiple-new') {
-                // Create separate lorebooks for each, using custom names
                 for (let i = 0; i < characterConfigs.length; i++) {
                     const config = characterConfigs[i];
                     const originalIndex = charactersData.indexOf(charactersData.find(c => c.name === config.name));
@@ -1310,21 +1310,37 @@ async function showBatchBabyBunnyPopup(charactersData) {
 
                     if (!lorebookName) {
                         toastr.error(`Please enter a lorebook name for ${config.entryName}`);
+                        resolve(false);
                         return;
                     }
 
-                    await processSingleCharacterArchive(config, lorebookName, true, scope);
+                    multipleLorebookNames.push(lorebookName);
+                }
+            } else if (mode === 'single-existing') {
+                singleLorebookName = popup.find('#batch-existing-lorebook').val();
+                if (!singleLorebookName) {
+                    toastr.error('Please select a lorebook');
+                    resolve(false);
+                    return;
+                }
+            }
+
+            overlay.remove();
+
+            // Process based on mode
+            if (mode === 'single-new') {
+                // Create single lorebook for all characters
+                await processBatchToSingleLorebook(characterConfigs, singleLorebookName, true, scope);
+
+            } else if (mode === 'multiple-new') {
+                // Create separate lorebooks for each, using custom names
+                for (let i = 0; i < characterConfigs.length; i++) {
+                    await processSingleCharacterArchive(characterConfigs[i], multipleLorebookNames[i], true, scope);
                 }
 
             } else if (mode === 'single-existing') {
-                const lorebookName = popup.find('#batch-existing-lorebook').val();
-                if (!lorebookName) {
-                    toastr.error('Please select a lorebook');
-                    return;
-                }
-
                 // Add all to existing lorebook
-                await processBatchToSingleLorebook(characterConfigs, lorebookName, false, scope);
+                await processBatchToSingleLorebook(characterConfigs, singleLorebookName, false, scope);
             }
 
             resolve(true);
@@ -1436,7 +1452,7 @@ async function createNewLorebook(name) {
     try {
         await createNewWorldInfo(name);
         CarrotDebug.ui('🐰 BATCH PROCESSING: Created new lorebook', { name });
-        return { name, entries: [] };
+        return await loadWorldInfo(name);
     } catch (error) {
         CarrotDebug.error('🐰 BATCH PROCESSING ERROR: Failed to create lorebook', error);
         return null;
@@ -1458,7 +1474,10 @@ async function loadExistingLorebook(name) {
 // Helper function: Save lorebook using ST's API
 async function saveLorebook(lorebook, name) {
     try {
-        await saveWorldInfo(name, lorebook);
+        // immediately=true: saveWorldInfo's debounced path shares a single timer, so a
+        // batch loop saving several lorebooks back-to-back would otherwise only ever
+        // persist the last one once the timer finally fires.
+        await saveWorldInfo(name, lorebook, true);
         CarrotDebug.ui('🐰 BATCH PROCESSING: Saved lorebook', { name });
         return true;
     } catch (error) {
@@ -2113,8 +2132,10 @@ async function activateLorebook(lorebookName, activationScope) {
                 // Directly add to selected_world_info array and save
                 if (!selected_world_info.includes(lorebookName)) {
                     selected_world_info.push(lorebookName);
-                    saveSettingsDebounced();
-                    await updateWorldInfoList(); // Update UI to show selection
+                    await updateWorldInfoList(); // Rebuild <option> elements, then let ST's own
+                    // change handler persist the selection into world_info.globalSelect —
+                    // saveSettingsDebounced() alone never writes that field.
+                    $('#world_info').trigger('change');
 
                     CarrotDebug.ui('🐰 ✅ Added to selected_world_info and saved settings');
                     toastr.success(`Lorebook "${lorebookName}" activated globally`);
@@ -2305,28 +2326,24 @@ async function createCharacterArchive(characterName, triggers, lorebookName, tag
             currentWorldInfoStructure: Object.keys(currentWorldInfo)
         });
 
-        // Save the updated lorebook (following NemoLore's exact pattern)
-        await saveWorldInfo(lorebookName, currentWorldInfo);
+        // Save the updated lorebook immediately. saveWorldInfo's debounced path only
+        // populates the in-memory worldInfoCache synchronously and defers the actual
+        // fetch — the old "wait 1s then loadWorldInfo() to verify" approach re-read
+        // that same synchronous cache, so it always "passed" without ever confirming
+        // the write reached the server, and the follow-up updateWorldInfoList() call
+        // could race the not-yet-fired debounced write. immediately=true awaits the
+        // real fetch and emits WORLDINFO_UPDATED, making both problems moot.
+        await saveWorldInfo(lorebookName, currentWorldInfo, true);
 
-        // Step 4.5: Wait a moment and verify the save actually worked
-        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait 1 second for file system
+        const savedEntriesCount = Object.keys(currentWorldInfo.entries || {}).length;
 
-        // Verify the lorebook was actually saved with entries
-        const verificationWorldInfo = await loadWorldInfo(lorebookName);
-        const savedEntriesCount = Object.keys(verificationWorldInfo?.entries || {}).length;
-
-        CarrotDebug.ui('🐰 BABY BUNNY DEBUG: Save verification', {
+        CarrotDebug.ui('🐰 BABY BUNNY DEBUG: Save complete', {
             lorebookName,
             savedEntriesCount,
-            verificationPassed: savedEntriesCount > 0,
-            savedEntries: Object.keys(verificationWorldInfo?.entries || {})
+            savedEntries: Object.keys(currentWorldInfo.entries || {})
         });
 
-        if (savedEntriesCount === 0) {
-            throw new Error('Lorebook was created but entries were not saved properly');
-        }
-
-        // Only update the UI AFTER verification passes
+        // Update the UI now that the save has actually completed
         await updateWorldInfoList();
 
         // Step 5: Register as character repo in CarrotKernel settings
@@ -4097,6 +4114,20 @@ function add_baby_bunny_button_to_message(messageId) {
 function add_baby_bunny_buttons_to_all_existing_messages() {
     CarrotDebug.ui('🐰 Adding Baby Bunny buttons to all existing messages...');
 
+    // Re-prime #message_template so any message cloned from it later (chat switch,
+    // reload) still gets the button, using the same "already exists" guard as
+    // add_baby_bunny_button_to_message().
+    const templateExtraButtons = $("#message_template .mes_buttons .extraMesButtons");
+    if (templateExtraButtons.find(`.${baby_bunny_button_class}`).length === 0) {
+        let templateHtml = `<div title="🐰 Manual Baby Bunny Mode - Process this message as a character sheet" class="mes_button ${baby_bunny_button_class}" tabindex="0">
+        <svg width="23" height="23" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M8.097.298a2.19 2.19 0 0 0-2.145.687a4.03 4.03 0 0 0-.735 3.981c.534 1.742 1.517 4.657 2.264 6.743c.044.12.157.2.284.201h8.094a.31.31 0 0 0 .272-.19c.249-.627.533-1.362.83-2.144a.26.26 0 0 0-.107-.308a5.8 5.8 0 0 1-1.327-1.185a10.4 10.4 0 0 1-2.3-3.851a.1.1 0 0 0-.07-.024a.07.07 0 0 0-.071.06c-.225.912-.77 3.222-1.043 4.443a.31.31 0 0 1-.296.237a.284.284 0 0 1-.285-.237c-.438-2.086-.948-4.432-1.315-5.842C9.602.96 8.654.439 8.097.297m11.755 8.627a1.67 1.67 0 0 0 1.244-2.37a9.36 9.36 0 0 0-3.496-4.16a5.3 5.3 0 0 0-2.133-.532c-.533 0-.983.142-1.125.568c-.439 1.185 1.185 3.875 2.145 4.954a4.18 4.18 0 0 0 3.365 1.54M2.74 14.873c0 .654.531 1.185 1.186 1.185h2.192a.32.32 0 0 1 .225.094a.3.3 0 0 1 .071.237l-.794 5.522a1.6 1.6 0 0 0 .427 1.327c.349.339.817.526 1.303.522h8.177a1.85 1.85 0 0 0 1.303-.521c.356-.345.527-.837.462-1.328l-.794-5.522a.3.3 0 0 1 .071-.237a.32.32 0 0 1 .226-.094h2.488a1.185 1.185 0 1 0 0-2.37H3.878a1.185 1.185 0 0 0-1.137 1.185"/>
+        </svg>
+    </div>`;
+        templateExtraButtons.prepend(templateHtml);
+        CarrotDebug.ui('🐰 Re-primed #message_template with Baby Bunny button');
+    }
+
     const allMessages = $("#chat .mes");
     CarrotDebug.ui(`🐰 Found ${allMessages.length} existing messages to process`);
 
@@ -4116,7 +4147,12 @@ function add_baby_bunny_buttons_to_all_existing_messages() {
 function remove_all_baby_bunny_buttons() {
     CarrotDebug.ui('🐰 Removing all Baby Bunny buttons...');
 
-    const buttons = $(`.${baby_bunny_button_class}`);
+    // Scope removal to #chat only. #message_template is ST's live, cached template
+    // node (not an inert <template>) — a document-wide selector would strip the
+    // button out of it too, and nothing ever re-primes it, so every message cloned
+    // from the template afterward (chat switches, reloads) would permanently lose
+    // the button until a full page reload.
+    const buttons = $(`#chat .${baby_bunny_button_class}`);
     const count = buttons.length;
     buttons.remove();
 

--- a/card-renderer.js
+++ b/card-renderer.js
@@ -5,6 +5,28 @@
 
 import { CarrotDebug } from './debugger.js';
 import { generateFullSheet, generateTagSheet, generateQuickSheet } from './sheet-generator.js';
+import { extension_settings } from '../../../extensions.js';
+import { EXTENSION_NAME } from './carrot-state.js';
+
+const extensionName = EXTENSION_NAME;
+
+// Forward declarations - provided by index.js via initializeCardRenderer() to avoid
+// a circular dependency (mirrors the same pattern sheet-generator.js and
+// repository-manager.js already use for their own index.js-owned dependencies).
+let findCharacterByName = null;
+let refreshTabContent = null;
+
+/**
+ * Initialize the card renderer with required dependencies
+ * Called by index.js after it defines findCharacterByName/refreshTabContent
+ * @param {Function} findCharFn - The findCharacterByName function from index.js
+ * @param {Function} refreshTabFn - The refreshTabContent function from index.js
+ */
+export function initializeCardRenderer(findCharFn, refreshTabFn) {
+    findCharacterByName = findCharFn;
+    refreshTabContent = refreshTabFn;
+    CarrotDebug.init('Card renderer initialized with dependencies');
+}
 
 function renderAsCards(activeCharacters) {
     const settings = extension_settings[extensionName];
@@ -16,8 +38,11 @@ function renderAsCards(activeCharacters) {
     // Load CSS styles first (create style element if needed)
     loadCarrotCardStyles();
     
+    // createCharacterCard returns a DOM element, not a string — without .outerHTML
+    // this joins to the literal text "[object HTMLDivElement]" for every card.
     const cardsHTML = charactersToShow
         .map((charName, index) => createCharacterCard(charName, index))
+        .map(el => el.outerHTML)
         .join('');
     
     // Add a header for the system message with character count (EXACT BunnyMoTags format)

--- a/chunk-visualizer.js
+++ b/chunk-visualizer.js
@@ -863,6 +863,37 @@ function bindChunkVisualizerEvents() {
         renderChunks(modifiedChunks, getSearchTerm());
     });
 
+    // Add Chunk functionality
+    $('#carrot-rag-add-chunk').off('click').on('click', function() {
+        // Create a new chunk with template structure
+        const newHash = `chunk_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        const newChunk = {
+            text: '',
+            comment: 'New Chunk',
+            section: 'Custom Section',
+            topic: null,
+            tags: [],
+            keywords: [],
+            systemKeywords: [],
+            defaultSystemKeywords: [],
+            keywordGroups: [],
+            defaultKeywordGroups: [],
+            keywordRegex: [],
+            defaultKeywordRegex: [],
+            customKeywords: [],
+            customRegex: [],
+            disabledKeywords: [],
+            customWeights: {},
+            index: Object.keys(modifiedChunks).length,
+            _editing: true, // Open by default
+        };
+
+        modifiedChunks[newHash] = newChunk;
+        hasUnsavedChanges = true;
+        toastr.success('New chunk created! Remember to save when done.');
+        renderChunks(modifiedChunks, getSearchTerm());
+    });
+
     // Toggle chunk expansion
     $container.off('click', '.carrot-chunk-toggle-drawer').on('click', '.carrot-chunk-toggle-drawer', function() {
         const hash = $(this).data('hash');
@@ -1037,6 +1068,66 @@ function bindChunkVisualizerEvents() {
             const link = chunk.chunkLinks.find(l => l.targetHash === targetHash);
             if (link) link.mode = mode;
         });
+
+        hasUnsavedChanges = true;
+        renderChunks(modifiedChunks, getSearchTerm());
+    });
+
+    // System keyword toggle (enable/disable a detected keyword)
+    $container.off('change', '.carrot-system-keyword-toggle').on('change', '.carrot-system-keyword-toggle', function() {
+        const hash = $(this).data('hash');
+        const keyword = $(this).data('keyword');
+        const chunk = modifiedChunks[hash];
+        if (!chunk) return;
+
+        const normalized = normalizeKeywordClient(keyword);
+        chunk.disabledKeywords = ensureArrayValue(chunk.disabledKeywords).map(normalizeKeywordClient);
+
+        if (this.checked) {
+            chunk.disabledKeywords = chunk.disabledKeywords.filter(value => value !== normalized);
+        } else if (!chunk.disabledKeywords.includes(normalized)) {
+            chunk.disabledKeywords.push(normalized);
+        }
+        initializeChunkKeywordMetadata(chunk);
+        hasUnsavedChanges = true;
+        renderChunks(modifiedChunks, getSearchTerm());
+    });
+
+    // Keyword weight input
+    $container.off('change', '.carrot-keyword-weight-input').on('change', '.carrot-keyword-weight-input', function() {
+        const hash = $(this).data('hash');
+        const keyword = $(this).data('keyword');
+        const chunk = modifiedChunks[hash];
+        if (!chunk) return;
+
+        const newWeight = parseInt($(this).val(), 10);
+        const normalized = normalizeKeywordClient(keyword);
+        const defaultPriority = fullsheetAPI.getKeywordPriority ? fullsheetAPI.getKeywordPriority(keyword) : 20;
+
+        if (!chunk.customWeights) {
+            chunk.customWeights = {};
+        }
+
+        // Only store if different from default
+        if (newWeight !== defaultPriority && !isNaN(newWeight)) {
+            chunk.customWeights[normalized] = newWeight;
+        } else {
+            delete chunk.customWeights[normalized];
+        }
+
+        hasUnsavedChanges = true;
+        renderChunks(modifiedChunks, getSearchTerm());
+    });
+
+    // Reset weight to default
+    $container.off('click', '.carrot-reset-weight-btn').on('click', '.carrot-reset-weight-btn', function() {
+        const hash = $(this).data('hash');
+        const keyword = $(this).data('keyword');
+        const chunk = modifiedChunks[hash];
+        if (!chunk || !chunk.customWeights) return;
+
+        const normalized = normalizeKeywordClient(keyword);
+        delete chunk.customWeights[normalized];
 
         hasUnsavedChanges = true;
         renderChunks(modifiedChunks, getSearchTerm());

--- a/fullsheet-rag.js
+++ b/fullsheet-rag.js
@@ -474,7 +474,7 @@ async function apiDeleteVectorHashes(collectionId, hashes) {
         throw new Error(`Failed to delete vectors from ${collectionId}. Status: ${response.status}. Message: ${errorText}`);
     }
 
-    return await response.json();
+    return true;
 }
 
 /**
@@ -498,7 +498,7 @@ async function apiDeleteCollection(collectionId) {
         throw new Error(`Failed to purge collection ${collectionId}. Status: ${response.status}. Message: ${errorText}`);
     }
 
-    return await response.json();
+    return true;
 }
 
 /**
@@ -523,6 +523,13 @@ async function updateChunksInLibrary(collectionId, chunks) {
 
     const chunksToRevectorize = [];
     const updatedHashes = [];
+
+    // Determine which chunks were deleted (present in library, absent from the submitted set)
+    // so they can be removed from the library and purged from the vector DB below.
+    const removedHashes = Object.keys(library[collectionId]).filter(hash => !(hash in chunks));
+    for (const hash of removedHashes) {
+        delete library[collectionId][hash];
+    }
 
     // Process each modified chunk
     for (const [hash, chunkData] of Object.entries(chunks)) {
@@ -568,6 +575,17 @@ async function updateChunksInLibrary(collectionId, chunks) {
     // Save updated library to extension_settings
     saveSettingsDebounced();
     CarrotDebug.ui(`✅ Updated ${updatedHashes.length} chunks in library`);
+
+    // Purge deleted chunks' vectors from the vector DB
+    if (removedHashes.length > 0) {
+        CarrotDebug.ui(`🗑️  Purging ${removedHashes.length} deleted chunks from vector DB...`);
+        try {
+            await purgeOrphanedVectors(collectionId, removedHashes.map(Number));
+        } catch (error) {
+            CarrotDebug.error('❌ Failed to purge deleted chunks:', error);
+            toastr.error(`Failed to purge deleted chunks: ${error.message}`);
+        }
+    }
 
     // Re-vectorize chunks with changed text
     if (chunksToRevectorize.length > 0) {
@@ -627,6 +645,7 @@ function getRAGSettings() {
         keywordFallback: ragState.keywordFallback ?? true,
         keywordFallbackPriority: ragState.keywordFallbackPriority ?? false,
         keywordFallbackLimit: ragState.keywordFallbackLimit ?? 2,
+        disabledCollections: ragState.disabledCollections ?? [],
     };
 }
 
@@ -2146,8 +2165,8 @@ function buildChunkText(section, topic, tags, body) {
  */
 function stripTagSynthesis(content) {
     // Check if TAG SYNTHESIS exclusion is enabled
-    const settings = getRAGSettings();
-    if (!settings.excludeTagSynthesis) {
+    const excludeTagSynthesis = extension_settings[extensionName]?.excludeTagSynthesis;
+    if (!excludeTagSynthesis) {
         return content; // Don't strip if setting is disabled
     }
 
@@ -2649,6 +2668,10 @@ function libraryEntryToChunk(hash, data, additional = {}) {
         customKeywords,
         customRegex,
         disabledKeywords,
+        disabled: data.disabled ?? false,
+        chunkLinks: ensureArray(data.chunkLinks),
+        inclusionGroup: data.inclusionGroup ?? '',
+        inclusionPrioritize: !!data.inclusionPrioritize,
         index: data.index ?? additional.index ?? 0,
     }, additional);
 }
@@ -3094,9 +3117,10 @@ async function queryRAG(characterName, queryText) {
             continue;
         }
 
-        // Filter to only activated collections (based on keywords/alwaysActive)
+        // Filter to only activated collections (based on keywords/alwaysActive),
+        // excluding any collection the user has explicitly disabled
         let collectionsInLibrary = Object.keys(library).filter(collectionId => {
-            return activatedCollections.has(collectionId);
+            return activatedCollections.has(collectionId) && !settings.disabledCollections?.includes(collectionId);
         });
         debugLog(`Checking ${libName} library:`, {
             hasLibrary: true,
@@ -3498,7 +3522,7 @@ async function injectRAGResults(characterName, results) {
                 headerParts.push('linked');
             }
 
-            const lines = ['### ' + headerParts.join(' � ')];
+            const lines = ['### ' + headerParts.join(' — ')];
 
             if (chunk.tags?.length) {
                 lines.push('Tags: ' + chunk.tags.join(', '));
@@ -3525,9 +3549,9 @@ async function injectRAGResults(characterName, results) {
             }
 
             lines.push(chunk.text.trim());
-            return lines.join('\\n');
+            return lines.join('\n');
         })
-        .join('\\n\\n');
+        .join('\n\n');
 
     setExtensionPrompt(
         RAG_PROMPT_TAG,
@@ -3645,7 +3669,7 @@ function addRAGButtonToMessage(messageId) {
     }
 
     // Get message data
-    const message = chat.find(msg => msg.index === messageId);
+    const message = chat[messageId];
     if (!message || !message.mes) {
         return;
     }
@@ -3817,7 +3841,7 @@ async function vectorizeFullsheetFromMessage(characterName, content) {
         // Step 2: Get existing hashes
         CarrotDebug.ui('\n🔍 STEP 2: Checking for existing chunks in vector DB...');
         const savedHashes = await apiGetSavedHashes(collectionId);
-        const savedHashSet = new Set(savedHashes.map(h => h.hash));
+        const savedHashSet = new Set(savedHashes);
         CarrotDebug.ui(`✅ STEP 2 COMPLETE: Found ${savedHashes.length} existing hashes`);
         if (savedHashes.length > 0) {
             CarrotDebug.ui(`   Existing hashes:`, Array.from(savedHashSet));
@@ -3858,7 +3882,8 @@ async function vectorizeFullsheetFromMessage(characterName, content) {
         chunks.forEach(chunk => {
             library[collectionId][chunk.hash] = {
                 text: chunk.text,
-                ...chunk.metadata
+                ...chunk.metadata,
+                chunkLinks: chunk.chunkLinks,
             };
         });
 
@@ -3894,12 +3919,13 @@ async function vectorizeFullsheetFromMessage(characterName, content) {
         CarrotDebug.ui('\n🏷️  STEP 6: Tracking embedding provider...');
         const vectorSettings = getVectorSettings();
         // ragState already declared above, just reuse it
+        const currentEmbeddingModel = getVectorsRequestBody({}).model || null;
         ragState.lastEmbeddingSource = vectorSettings.source;
-        ragState.lastEmbeddingModel = vectorSettings.model || null;
+        ragState.lastEmbeddingModel = currentEmbeddingModel;
         saveSettingsDebounced();
         CarrotDebug.ui(`✅ STEP 6 COMPLETE: Tracked embedding provider`);
         CarrotDebug.ui(`   Source: ${vectorSettings.source}`);
-        CarrotDebug.ui(`   Model: ${vectorSettings.model || 'default'}`);
+        CarrotDebug.ui(`   Model: ${currentEmbeddingModel || 'default'}`);
 
         CarrotDebug.ui('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
         CarrotDebug.ui(`✅ VECTORIZATION SUCCESSFUL: ${characterName}`);
@@ -3964,9 +3990,11 @@ function removeAllRAGButtons() {
 function initializeRAG() {
     debugLog('Initializing CarrotKernel RAG system');
 
-    // Register RAG interceptor for generation events
-    eventSource.on(event_types.GENERATION_STARTED, carrotKernelRagInterceptor_CK);
-    debugLog('✅ RAG interceptor registered for GENERATION_STARTED');
+    // RAG interceptor is registered via manifest.json's generate_interceptor
+    // (carrotKernelRagInterceptor_CK), which supplies the correct (chat, contextSize,
+    // abort, type) signature. Do not also register it as a GENERATION_STARTED
+    // listener here — that event passes a different argument shape and would
+    // double-run the interceptor on every generation.
 
     // Hook into message events for button detection
     eventSource.on(event_types.CHARACTER_MESSAGE_RENDERED, (messageId) => {
@@ -4005,7 +4033,7 @@ function initializeRAG() {
  * @param {number} messageId - Message ID
  */
 async function autoVectorizeMessage(messageId) {
-    const message = chat.find(msg => msg.index === messageId);
+    const message = chat[messageId];
     if (!message || !message.mes || message.is_user) {
         return;
     }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { eventSource, event_types, chat, saveSettingsDebounced, chat_metadata, addOneMessage, this_chid, characters, generateQuietPrompt, animation_duration, setExtensionPrompt, extension_prompt_types, extension_prompt_roles } from '../../../../script.js';
+import { eventSource, event_types, chat, saveSettingsDebounced, chat_metadata, addOneMessage, this_chid, characters, generateQuietPrompt, animation_duration, setExtensionPrompt, extension_prompt_types, extension_prompt_roles, messageFormatting, saveChatConditional, saveChatDebounced } from '../../../../script.js';
 import { getTokenCountAsync } from '../../../../scripts/tokenizers.js';
 import { extension_settings, getContext, writeExtensionField, saveMetadataDebounced } from '../../../extensions.js';
 import { loadWorldInfo, world_names, createNewWorldInfo, createWorldInfoEntry, saveWorldInfo, updateWorldInfoList, selected_world_info, world_info, METADATA_KEY, parseRegexFromString } from '../../../world-info.js';
@@ -38,7 +38,7 @@ import {
     clearPendingThinkingBlockData,
     EXTENSION_NAME
 } from './carrot-state.js';
-import { renderAsCards, loadCarrotCardStyles, attachExternalCardsToMessage, ensureBunnyMoAnimations, createExternalCardContainer, createTabbedCharacterCard, createCharacterCard } from './card-renderer.js';
+import { renderAsCards, loadCarrotCardStyles, attachExternalCardsToMessage, ensureBunnyMoAnimations, createExternalCardContainer, createTabbedCharacterCard, createCharacterCard, initializeCardRenderer } from './card-renderer.js';
 import { initializeUIUpdates, updateStatusPanels } from './ui-updates.js';
 import { initializeTutorials, openSystemTutorial, openRepositoryTutorial, openInjectionTutorial, openTemplateEditorTutorial, startTutorial, closeTutorial } from './tutorials.js';
 import { checkForCompletedSheets, initialize_baby_bunny_message_button, add_baby_bunny_button_to_message, add_baby_bunny_buttons_to_all_existing_messages, remove_all_baby_bunny_buttons, showTutorialBabyBunnyPopup, closeBabyBunnyTutorial, baby_bunny_button_class } from './baby-bunny-mode.js';
@@ -99,6 +99,9 @@ async function loadFullsheetRAG() {
                 CarrotDebug.error('updateChunksInLibrary not implemented in fullsheet-rag.js');
                 return Promise.resolve();
             }),
+            apiInsertVectorItems: module.apiInsertVectorItems || (() => Promise.resolve()),
+            deleteEntireCollection: module.deleteEntireCollection || (() => Promise.resolve()),
+            purgeOrphanedVectors: module.purgeOrphanedVectors || (() => Promise.resolve()),
         };
         return fullsheetAPI;
     } catch (error) {
@@ -364,8 +367,17 @@ async function showCopyContextPopup(collectionId, sourceContext) {
             $(this).closest('.copy-context-option').css('border-color', 'var(--SmartThemeQuoteColor, #10b981)');
         });
 
+        // ESC key to cancel
+        const handleCopyContextEscape = (e) => {
+            if (e.key === 'Escape') {
+                popup.find('#copy-context-cancel').click();
+            }
+        };
+        $(document).on('keydown', handleCopyContextEscape);
+
         // Cancel button
         popup.find('#copy-context-cancel').on('click', () => {
+            $(document).off('keydown', handleCopyContextEscape);
             $overlay.removeClass('active');
             setTimeout(() => {
                 $overlay.hide().empty();
@@ -380,18 +392,12 @@ async function showCopyContextPopup(collectionId, sourceContext) {
                 toastr.warning('Please select a destination storage level');
                 return;
             }
+            $(document).off('keydown', handleCopyContextEscape);
             $overlay.removeClass('active');
             setTimeout(() => {
                 $overlay.hide().empty();
             }, 300);
             resolve(selectedLevel);
-        });
-
-        // ESC key to cancel
-        $(document).one('keydown', (e) => {
-            if (e.key === 'Escape') {
-                popup.find('#copy-context-cancel').click();
-            }
         });
     });
 }
@@ -1043,9 +1049,7 @@ export async function wrapLorebookEntries(lorebookName) {
         toastr.success(`Wrapped ${wrappedCount} entries in ${lorebookName}`);
 
         // Reload worldbook list to reflect changes
-        if (typeof loadWorldInfoList === 'function') {
-            loadWorldInfoList();
-        }
+        await updateWorldInfoList();
 
         return true;
     } catch (error) {
@@ -1128,9 +1132,7 @@ export async function unwrapLorebookEntries(lorebookName) {
         toastr.success(`Unwrapped ${unwrappedCount} entries in ${lorebookName}`);
 
         // Reload worldbook list to reflect changes
-        if (typeof loadWorldInfoList === 'function') {
-            loadWorldInfoList();
-        }
+        await updateWorldInfoList();
 
         return true;
     } catch (error) {
@@ -2306,9 +2308,7 @@ function displayCharacterData(injectedCharacters) {
                         }
                         
                         // Save the chat to persist the data
-                        if (typeof saveChatDebounced === 'function') {
-                            saveChatDebounced();
-                        }
+                        saveChatDebounced();
                         
                         CarrotDebug.ui('💾 PERSISTENCE: Character data saved to message.extra', {
                             messageId: messageId,
@@ -2979,7 +2979,7 @@ async function addPersistentTagsToMessage(messageId) {
 
     try {
         // Find the message in chat array
-        const message = chat.find(msg => msg.index === messageId);
+        const message = chat[messageId];
         if (!message || message.is_user) {
             CarrotDebug.inject('❌ Message not found or is user message', {
                 messageId: messageId,
@@ -3040,7 +3040,13 @@ function generatePersistentTagsBlock(characterNames) {
     let content = '<BunnyMoTags>\n';
     
     characterNames.forEach(charName => {
-        const charData = scannedCharacters.get(charName);
+        let charData = null;
+        for (const [key, value] of scannedCharacters) {
+            if (key.endsWith(`::${charName}`)) {
+                charData = value;
+                break;
+            }
+        }
         if (charData && charData.tags) {
             content += `${charName}:\n`;
             
@@ -4530,23 +4536,18 @@ async function executeInstall(path, filename) {
         const entries = data.entries || [];
         
         // Step 3: Install
+        // Delegate to installPackNative(), which uses ST's actual /api/worldinfo/import
+        // contract (a multipart file upload) instead of a raw JSON POST that endpoint rejects.
         progressTextEl.textContent = 'Installing to SillyTavern lorebooks...';
         progressFillEl.style.width = '75%';
-        
+
         const cleanName = filename.replace('.json', '');
-        const saveResponse = await fetch('/api/worldinfo/import', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ 
-                name: cleanName,
-                data: data 
-            })
-        });
-        
-        if (!saveResponse.ok) {
-            throw new Error(`Failed to install lorebook: ${saveResponse.status}`);
+        const installed = await installPackNative(downloadUrl, filename);
+
+        if (!installed) {
+            throw new Error('Failed to install lorebook');
         }
-        
+
         // Step 4: Track installation with SHA
         const currentItem = githubBrowser.currentItems.find(item => item.path === path);
         if (currentItem) {
@@ -4594,10 +4595,8 @@ async function executeInstall(path, filename) {
         }, 500);
         
         // Refresh ST's lorebook list
-        if (typeof loadWorldInfoList === 'function') {
-            loadWorldInfoList();
-        }
-        
+        await updateWorldInfoList();
+
     } catch (error) {
         CarrotDebug.error('Installation error:', error);
         
@@ -4635,7 +4634,7 @@ async function executeInstall(path, filename) {
 // Close installation dialog
 }
 function closeInstallDialog() {
-    closePopup();
+    closeCarrotPopup();
     // Return to the browser
     showPackManagerInterface();
 }
@@ -7211,6 +7210,11 @@ function registerEventListeners() {
         initializeSheetGenerator(findCharacterByName);
         CarrotDebug.init('Sheet generator initialized with findCharacterByName');
 
+        // Initialize card renderer with findCharacterByName/refreshTabContent —
+        // same circular-dependency fix as sheet generator above.
+        initializeCardRenderer(findCharacterByName, refreshTabContent);
+        CarrotDebug.init('Card renderer initialized with dependencies');
+
         // Load settings HTML - silent initialization
         const settingsHtml = await $.get(`scripts/extensions/third-party/${extensionName}/settings.html`);
         $('#extensions_settings').append(settingsHtml);
@@ -8145,14 +8149,17 @@ function bindSettingsEvents() {
                 }
             }
 
-            // Update tracked provider to current
-            const current = getCurrentProvider();
-            ragState.lastEmbeddingSource = current.source;
-            ragState.lastEmbeddingModel = current.model;
-            await persistRagSettings();
+            // Only mark the provider as up to date if every collection actually re-vectorized;
+            // otherwise the warning must keep showing since some collections are still on the old provider.
+            if (failCount === 0) {
+                const current = getCurrentProvider();
+                ragState.lastEmbeddingSource = current.source;
+                ragState.lastEmbeddingModel = current.model;
+                await persistRagSettings();
 
-            // Hide warning
-            $('#carrot_rag_provider_warning').slideUp(200);
+                // Hide warning
+                $('#carrot_rag_provider_warning').slideUp(200);
+            }
 
             if (successCount > 0) {
                 toastr.success(`Re-vectorized ${successCount} collection(s) successfully`);
@@ -8429,261 +8436,8 @@ function bindSettingsEvents() {
             return { totalChunks, totalSize, avgSize, sectionCount };
         },
     };
-
-        $('.carrot-system-keyword-toggle').on('change', function() {
-            const hash = $(this).data('hash');
-            const keyword = $(this).data('keyword');
-            const chunk = modifiedChunks[hash];
-            if (!chunk) {
-                return;
-            }
-
-            const normalized = normalizeKeywordClient(keyword);
-            chunk.disabledKeywords = ensureArrayValue(chunk.disabledKeywords).map(normalizeKeywordClient);
-
-            if (this.checked) {
-                chunk.disabledKeywords = chunk.disabledKeywords.filter(value => value !== normalized);
-            } else if (!chunk.disabledKeywords.includes(normalized)) {
-                chunk.disabledKeywords.push(normalized);
-            }
-            updateChunkKeywordCache(chunk);
-            renderChunks(modifiedChunks, getSearchTerm());
-        });
-
-        // Keyword weight input handler
-        $('.carrot-keyword-weight-input').on('change', function() {
-            const hash = $(this).data('hash');
-            const keyword = $(this).data('keyword');
-            const chunk = modifiedChunks[hash];
-            if (!chunk) {
-                return;
-            }
-
-            const newWeight = parseInt($(this).val(), 10);
-            const normalized = normalizeKeywordClient(keyword);
-            const defaultPriority = fullsheetAPI.getKeywordPriority ? fullsheetAPI.getKeywordPriority(keyword) : 20;
-
-            if (!chunk.customWeights) {
-                chunk.customWeights = {};
-            }
-
-            // Only store if different from default
-            if (newWeight !== defaultPriority && !isNaN(newWeight)) {
-                chunk.customWeights[normalized] = newWeight;
-            } else {
-                delete chunk.customWeights[normalized];
-            }
-
-            renderChunks(modifiedChunks, getSearchTerm());
-        });
-
-        // Reset weight button handler
-        $('.carrot-reset-weight-btn').on('click', function() {
-            const hash = $(this).data('hash');
-            const keyword = $(this).data('keyword');
-            const chunk = modifiedChunks[hash];
-            if (!chunk || !chunk.customWeights) {
-                return;
-            }
-
-            const normalized = normalizeKeywordClient(keyword);
-            delete chunk.customWeights[normalized];
-
-            renderChunks(modifiedChunks, getSearchTerm());
-        });
-
-        // Keyword weight display click handler
-        // Keyword toggle button handler (enable/disable)
-        $('.carrot-keyword-toggle-btn').on('click', function() {
-            const hash = $(this).data('hash');
-            const keyword = $(this).data('keyword');
-            const chunk = modifiedChunks[hash];
-            if (!chunk) {
-                return;
-            }
-
-            const normalized = normalizeKeywordClient(keyword);
-            chunk.disabledKeywords = ensureArrayValue(chunk.disabledKeywords).map(normalizeKeywordClient);
-
-            const isDisabled = chunk.disabledKeywords.includes(normalized);
-            if (isDisabled) {
-                chunk.disabledKeywords = chunk.disabledKeywords.filter(value => value !== normalized);
-            } else {
-                chunk.disabledKeywords.push(normalized);
-            }
-
-            updateChunkKeywordCache(chunk);
-            renderChunks(modifiedChunks, getSearchTerm());
-        });
-
-        // Show all keywords button handler
-        $('.carrot-show-all-keywords').on('click', function() {
-            const hash = $(this).data('hash');
-            const hiddenDiv = $(`#hidden-keywords-${hash}`);
-            const $btn = $(this);
-
-            if (hiddenDiv.is(':visible')) {
-                hiddenDiv.slideUp(200);
-                $btn.html('<i class="fa-solid fa-chevron-down"></i> Show more keywords');
-            } else {
-                hiddenDiv.slideDown(200);
-                $btn.html('<i class="fa-solid fa-chevron-up"></i> Show fewer keywords');
-            }
-        });
-
-        // Add linked section button handler
-        $('.carrot-add-linked-section').on('click', function() {
-            const hash = $(this).data('hash');
-            const chunk = modifiedChunks[hash];
-            if (!chunk) {
-                return;
-            }
-
-            // Get all sections from all chunks for selection
-            const allSections = Object.values(modifiedChunks)
-                .map(c => c.section)
-                .filter(s => s && s !== chunk.section);
-            const uniqueSections = [...new Set(allSections)].sort();
-
-            if (uniqueSections.length === 0) {
-                toastr.info('No other sections available to link');
-                return;
-            }
-
-            const sectionName = prompt(
-                `Add linked section:\n\nAvailable sections:\n${uniqueSections.slice(0, 10).join('\n')}${uniqueSections.length > 10 ? '\n...' : ''}\n\nEnter section name:`,
-                uniqueSections[0]
-            );
-
-            if (!sectionName || sectionName.trim() === '') return;
-
-            if (!chunk.linkedSections) {
-                chunk.linkedSections = [];
-            }
-
-            if (!chunk.linkedSections.includes(sectionName.trim())) {
-                chunk.linkedSections.push(sectionName.trim());
-                renderChunks(modifiedChunks, getSearchTerm());
-            }
-        });
-
-        // Remove linked section button handler
-        $('.carrot-remove-linked-section').on('click', function() {
-            const hash = $(this).data('hash');
-            const section = $(this).data('section');
-            const chunk = modifiedChunks[hash];
-            if (!chunk || !chunk.linkedSections) {
-                return;
-            }
-
-            chunk.linkedSections = chunk.linkedSections.filter(s => s !== section);
-            renderChunks(modifiedChunks, getSearchTerm());
-        });
-
-        // Chunk text edit handler
-        $('.carrot-chunk-text-edit').on('input', function() {
-            const hash = $(this).data('hash');
-            const chunk = modifiedChunks[hash];
-            if (!chunk) {
-                return;
-            }
-            chunk.text = $(this).val();
-        });
-
-        // Custom keywords edit handler
-        $('.carrot-custom-keywords').on('input', function() {
-            const hash = $(this).data('hash');
-            const chunk = modifiedChunks[hash];
-            if (!chunk) {
-                return;
-            }
-            const value = $(this).val();
-            chunk.customKeywords = value.split(/[,\n]+/).map(k => k.trim()).filter(Boolean);
-            updateChunkKeywordCache(chunk);
-        });
-
-        // Custom regex edit handler
-        $('.carrot-custom-regex').on('input', function() {
-            const hash = $(this).data('hash');
-            const chunk = modifiedChunks[hash];
-            if (!chunk) {
-                return;
-            }
-            chunk.customRegex = parseRegexList($(this).val());
-        });
-
-        // Reset keywords button handler
-        $('.carrot-reset-keywords').on('click', function() {
-            const hash = $(this).data('hash');
-            const chunk = modifiedChunks[hash];
-            if (!chunk) {
-                return;
-            }
-            chunk.disabledKeywords = [];
-            chunk.customWeights = {};
-            updateChunkKeywordCache(chunk);
-            renderChunks(modifiedChunks, getSearchTerm());
-        });
-
-        // Inclusion group input handler
-        $('.carrot-inclusion-group-input').on('input', function() {
-            const hash = $(this).data('hash');
-            const chunk = modifiedChunks[hash];
-            if (!chunk) return;
-            chunk.inclusionGroup = $(this).val().trim();
-            renderChunks(modifiedChunks, getSearchTerm());
-        });
-
-        // Inclusion prioritize checkbox handler
-        $('.carrot-inclusion-prioritize').on('change', function() {
-            const hash = $(this).data('hash');
-            const chunk = modifiedChunks[hash];
-            if (!chunk) return;
-            chunk.inclusionPrioritize = this.checked;
-        });
     }
-
-    // Chunk link checkbox handler (delegated event)
-    $(document).on('change', '.carrot-chunk-link-checkbox', function() {
-        const hash = $(this).data('hash');
-        const targetHash = $(this).data('target');
-        const chunk = modifiedChunks[hash];
-        if (!chunk) return;
-
-        if (!chunk.chunkLinks) chunk.chunkLinks = [];
-
-        if (this.checked) {
-            // Get selected mode from radio buttons
-            const mode = $(`.carrot-link-mode-radio[data-hash="${hash}"]:checked`).val() || 'soft';
-
-            // Add link if not already present
-            if (!chunk.chunkLinks.some(link => link.targetHash === targetHash)) {
-                chunk.chunkLinks.push({ targetHash, mode });
-            }
-        } else {
-            // Remove link
-            chunk.chunkLinks = chunk.chunkLinks.filter(link => link.targetHash !== targetHash);
-        }
-
-        hasUnsavedChanges = true;
-        renderChunks(modifiedChunks, getSearchTerm());
-    });
-
-    // Link mode radio button handler (delegated event)
-    $(document).on('change', '.carrot-link-mode-radio', function() {
-        const hash = $(this).data('hash');
-        const newMode = $(this).val();
-        const chunk = modifiedChunks[hash];
-        if (!chunk || !chunk.chunkLinks) return;
-
-        // Update mode for all existing links of this chunk
-        chunk.chunkLinks.forEach(link => {
-            link.mode = newMode;
-        });
-
-        hasUnsavedChanges = true;
-        renderChunks(modifiedChunks, getSearchTerm());
-    });
+    // end bindActualEvents()
 
     // Inline drawer toggle for linked chunks section - Let ST's native handler manage this
     // No custom handler needed since we're using ST's standard inline-drawer structure
@@ -8840,37 +8594,9 @@ function bindSettingsEvents() {
         }
     });
 
-    // Add Chunk functionality
-    $('#carrot-rag-add-chunk').on('click', function() {
-        // Create a new chunk with template structure
-        const newHash = `chunk_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-        const newChunk = {
-            text: '',
-            comment: 'New Chunk',
-            section: 'Custom Section',
-            topic: null,
-            tags: [],
-            keywords: [],
-            systemKeywords: [],
-            defaultSystemKeywords: [],
-            keywordGroups: [],
-            defaultKeywordGroups: [],
-            keywordRegex: [],
-            defaultKeywordRegex: [],
-            customKeywords: [],
-            customRegex: [],
-            disabledKeywords: [],
-            customWeights: {},
-            index: Object.keys(modifiedChunks).length,
-            _editing: true, // Open by default
-        };
+    // Add Chunk functionality moved to chunk-visualizer.js's bindChunkVisualizerEvents(),
+    // where modifiedChunks/renderChunks/getSearchTerm are actually in scope.
 
-        modifiedChunks[newHash] = newChunk;
-        toastr.success('New chunk created! Remember to save when done.');
-        renderChunks(modifiedChunks, getSearchTerm());
-    });
-
-    
     // Helper for the viewer to get data for a specific level
     // FIXED: Now only returns the CURRENT character/chat's library, not ALL characters/chats
     function getFullLibraryForLevel(level) {
@@ -9469,6 +9195,8 @@ function bindSettingsEvents() {
         if (!window.CarrotPackManager) {
             CarrotDebug.error('❌ PACK MANAGER ERROR: window.CarrotPackManager not found!');
             $('#carrot-pack-status').html('<p>❌ Pack Manager not initialized. Please refresh the page.</p>');
+            packScanInProgress = false;
+            button.removeClass('clicked');
             return;
         }
 
@@ -9477,6 +9205,8 @@ function bindSettingsEvents() {
         if (typeof window.CarrotPackManager.scanRemotePacks !== 'function') {
             CarrotDebug.error('❌ PACK MANAGER ERROR: scanRemotePacks method not found!');
             $('#carrot-pack-status').html('<p>❌ Pack Manager scanRemotePacks method missing. Extension may be corrupted.</p>');
+            packScanInProgress = false;
+            button.removeClass('clicked');
             return;
         }
 
@@ -9663,12 +9393,15 @@ function bindSettingsEvents() {
         $('<style>.chat_lorebook_button { display: none !important; }</style>').appendTo('head');
     }
 
-    // Override "Link to World Info" dropdown option to use CarrotKernel connector
-    $(document).on('change', '#char-management-dropdown', function(e) {
-        const selectedValue = $(this).val();
-        if (selectedValue === 'default') return;
-
-        if (selectedValue === 'set_character_world') {
+    // Override "Link to World Info" dropdown option to use CarrotKernel connector.
+    // Match on the option's id, not its value — "Link to World Info" has no `value`
+    // attribute, so .val() falls back to the (now emoji-relabeled) option text and
+    // can never equal 'set_character_world'. Bind directly on the element (not
+    // delegated on document) so this fires alongside ST's own directly-bound handler
+    // rather than arriving late in the bubble phase.
+    $('#char-management-dropdown').on('change', function(e) {
+        const target = $(this.selectedOptions).attr('id');
+        if (target === 'set_character_world') {
             e.preventDefault();
             e.stopPropagation();
             CarrotLorebookConnector.open();
@@ -10124,7 +9857,7 @@ document.addEventListener('click', function(e) {
                 CarrotDebug.ui('Trying CarrotKernel.showPopup with proper parameters...');
                 try {
                     // Call showPopup with title and content parameters
-                    window.CarrotKernel.showCarrotPopup('WorldBook Tracker', '<div class="worldbook-tracker">Loading tracker...</div>');
+                    window.CarrotKernel.showPopup('WorldBook Tracker', '<div class="worldbook-tracker">Loading tracker...</div>');
                     CarrotDebug.ui('showPopup called successfully');
                 } catch (error) {
                     CarrotDebug.error('showPopup failed:', error);
@@ -10147,7 +9880,7 @@ document.addEventListener('click', function(e) {
                 CarrotDebug.ui('Trying to generate and show tracker HTML...');
                 try {
                     const trackerHTML = window.CarrotKernel.generateTrackerHTML();
-                    window.CarrotKernel.showCarrotPopup('WorldBook Tracker', trackerHTML);
+                    window.CarrotKernel.showPopup('WorldBook Tracker', trackerHTML);
                     CarrotDebug.ui('Tracker HTML generated and shown');
                 } catch (error) {
                     CarrotDebug.error('Tracker HTML generation failed:', error);

--- a/lorebook-connector.js
+++ b/lorebook-connector.js
@@ -285,7 +285,9 @@ function createConnectionPopup() {
 
     // Event handlers
     connectionPopup.find('.carrot-connection-close').on('click', () => CarrotLorebookConnector.close());
-    connectionPopup.find('.carrot-connection-overlay').on('click', function(e) {
+    // .carrot-connection-overlay is a root node of connectionPopup, not a descendant —
+    // .find() can never match it, so use .filter() to select it instead.
+    connectionPopup.filter('.carrot-connection-overlay').on('click', function(e) {
         if (e.target === this) {
             CarrotLorebookConnector.close();
         }
@@ -560,7 +562,10 @@ function handleSearch(e) {
 
 function handleStarClick(e) {
     e.stopPropagation();
-    const lorebookName = $(e.target).data('lorebook');
+    // .attr(), not .data() — jQuery coerces digit-only data-lorebook values (e.g. a
+    // lorebook literally named "2024") to Number, which then never matches the
+    // string entries held in the characterRepoBooks/tagLibraries Sets.
+    const lorebookName = $(e.target).attr('data-lorebook');
 
     // Star click should toggle PRIMARY status, not connection
     if (!currentConnections[lorebookName]) {
@@ -602,7 +607,7 @@ function handleStarClick(e) {
 }
 
 function handleScopeChange(e) {
-    const lorebookName = $(e.target).data('lorebook');
+    const lorebookName = $(e.target).attr('data-lorebook');
     const newScope = $(e.target).val();
 
     if (newScope === 'none') {
@@ -624,7 +629,7 @@ function handleScopeChange(e) {
 
 async function handleBadgeClick(e) {
     e.stopPropagation();
-    const lorebookName = $(e.currentTarget).data('lorebook');
+    const lorebookName = $(e.currentTarget).attr('data-lorebook');
     const currentType = $(e.currentTarget).data('type');
 
     // Cycle: repo → taglib → lorebook → repo
@@ -673,7 +678,7 @@ async function handleBadgeClick(e) {
 
 function handleOpenEditor(e) {
     e.stopPropagation();
-    const lorebookName = $(e.currentTarget).data('lorebook');
+    const lorebookName = $(e.currentTarget).attr('data-lorebook');
 
     // Close the CarrotKernel Lorebook Connector modal
     CarrotLorebookConnector.close();
@@ -730,18 +735,23 @@ async function applyConnections() {
     saveCharacterDebounced();
 
     // 2. Save additional character books to world_info.charLore[].extraBooks
+    // ST treats extensions.world (primary) and charLore[].extraBooks (auxiliary) as
+    // disjoint sets — exclude the primary here so it doesn't also show up selected
+    // in ST's native auxiliary multi-select.
+    const extraBooks = characterScopedBooks.filter(book => book !== primaryLorebook);
+
     const charFilename = getCharaFilename(this_chid);
     const charLore = world_info.charLore || [];
     const existingIndex = charLore.findIndex(entry => entry.name === charFilename);
 
-    if (characterScopedBooks.length > 0) {
+    if (extraBooks.length > 0) {
         if (existingIndex !== -1) {
-            charLore[existingIndex].extraBooks = characterScopedBooks;
+            charLore[existingIndex].extraBooks = extraBooks;
         } else {
-            charLore.push({ name: charFilename, extraBooks: characterScopedBooks });
+            charLore.push({ name: charFilename, extraBooks: extraBooks });
         }
     } else if (existingIndex !== -1) {
-        // Remove entry if no books
+        // Remove entry if no books, matching ST's own charSetAuxWorlds behavior
         charLore.splice(existingIndex, 1);
     }
 

--- a/pack-manager.js
+++ b/pack-manager.js
@@ -3,8 +3,9 @@
 // Manages BunnyMo pack installation, updates, and synchronization
 // =============================================================================
 
-import { saveSettingsDebounced } from '../../../../script.js';
+import { saveSettingsDebounced, getRequestHeaders } from '../../../../script.js';
 import { extension_settings } from '../../../extensions.js';
+import { updateWorldInfoList } from '../../../world-info.js';
 import { CarrotDebug } from './debugger.js';
 import { EXTENSION_NAME } from './carrot-state.js';
 
@@ -85,9 +86,16 @@ export class CarrotPackManager {
             this.rateLimitInfo.remaining = this.rateLimitInfo.limit; // Assume reset
         }
 
-        // If we're close to the limit, wait
+        // If we're close to the limit, wait — but only briefly. GitHub's
+        // unauthenticated limit resets hourly; silently sleeping until then made
+        // the scan appear to hang for up to 60 minutes with no user feedback.
         if (this.rateLimitInfo.remaining <= 5) {
             const waitTime = Math.max(0, this.rateLimitInfo.resetTime - now);
+            const MAX_WAIT_MS = 30000;
+            if (waitTime > MAX_WAIT_MS) {
+                const minutes = Math.ceil(waitTime / 60000);
+                throw new Error(`GitHub API rate limit reached — try again in ~${minutes} minute${minutes === 1 ? '' : 's'}`);
+            }
             if (waitTime > 0) {
                 CarrotDebug.repo(`⏳ Rate limit approaching, waiting ${Math.ceil(waitTime/1000)}s...`);
                 await this.delay(waitTime);
@@ -433,12 +441,15 @@ export class CarrotPackManager {
             // Install as ST lorebook
             const filename = `${packInfo.displayName.replace(/[^a-zA-Z0-9]/g, '_')}.json`;
             
-            const saveResponse = await fetch('/api/worldinfo/import', {
+            // /api/worldinfo/import only accepts multipart file uploads; /edit accepts
+            // exactly the { name, data } JSON shape already built here, plus it needs
+            // the CSRF token that getRequestHeaders() supplies.
+            const saveResponse = await fetch('/api/worldinfo/edit', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ name: filename, data: packData })
+                headers: getRequestHeaders(),
+                body: JSON.stringify({ name: filename.replace(/\.json$/i, ''), data: packData })
             });
-            
+
             if (!saveResponse.ok) {
                 throw new Error(`Failed to save lorebook: ${saveResponse.status}`);
             }
@@ -459,14 +470,12 @@ export class CarrotPackManager {
                 size: packInfo.size,
                 type: packInfo.type
             };
-            
+
             this.localPacks.set(packId, extension_settings[extensionName].installedPacks[packId]);
             saveSettingsDebounced();
-            
+
             // Refresh ST's lorebook list
-            if (typeof loadWorldInfoList === 'function') {
-                loadWorldInfoList();
-            }
+            await updateWorldInfoList();
 
             // Auto-scan newly installed pack for characters
             if (typeof window.CarrotKernel?.scanSelectedLorebooks === 'function') {
@@ -673,14 +682,14 @@ export class CarrotPackManager {
             // Install as native ST lorebook using ST's API
             const filename = `${packInfo.displayName.replace(/[^a-zA-Z0-9]/g, '_')}.json`;
             
-            // Use ST's native save lorebook functionality
-            const saveResponse = await fetch('/api/worldinfo/import', {
+            // Use ST's native save lorebook functionality. /api/worldinfo/import only
+            // accepts multipart file uploads; /edit accepts this { name, data } JSON
+            // body directly and just needs the CSRF token from getRequestHeaders().
+            const saveResponse = await fetch('/api/worldinfo/edit', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers: getRequestHeaders(),
                 body: JSON.stringify({
-                    name: filename,
+                    name: filename.replace(/\.json$/i, ''),
                     data: packData
                 })
             });
@@ -709,14 +718,12 @@ export class CarrotPackManager {
             };
             
             this.localPacks.set(packName, extension_settings[extensionName].installedPacks[packName]);
-            
+
             // Save settings
             saveSettingsDebounced();
-            
+
             // Refresh ST's lorebook list
-            if (typeof loadWorldInfoList === 'function') {
-                loadWorldInfoList();
-            }
+            await updateWorldInfoList();
 
             // Auto-scan newly installed pack for characters
             if (typeof window.CarrotKernel?.scanSelectedLorebooks === 'function') {
@@ -779,7 +786,7 @@ export class CarrotPackManager {
             extendedTimeOut: 0,
             closeButton: true,
             onclick: () => {
-                this.openPackManager();
+                window.CarrotKernel?.openPackManager();
             }
         });
     }
@@ -841,36 +848,34 @@ export class CarrotPackManager {
             
             const packData = await response.json();
             
-            // Update the lorebook file using ST's API
-            const updateResponse = await fetch('/api/worldinfo/import', {
+            // Update the lorebook file using ST's API. /api/worldinfo/import only
+            // accepts multipart file uploads; /edit accepts this JSON body directly
+            // (it always overwrites by filename — there's no server-side "overwrite"
+            // flag to pass) and needs the CSRF token from getRequestHeaders().
+            const updateResponse = await fetch('/api/worldinfo/edit', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers: getRequestHeaders(),
                 body: JSON.stringify({
-                    name: localPack.filename,
-                    data: packData,
-                    overwrite: true
+                    name: String(localPack.filename).replace(/\.json$/i, ''),
+                    data: packData
                 })
             });
-            
+
             if (!updateResponse.ok) {
                 throw new Error(`Failed to update lorebook: ${updateResponse.status}`);
             }
-            
+
             // Update our metadata
             localPack.version = remotePack.lastModified;
             localPack.updatedDate = Date.now();
             localPack.updateAvailable = false;
             delete localPack.newVersion;
-            
+
             extension_settings[extensionName].installedPacks[packName] = localPack;
             saveSettingsDebounced();
-            
+
             // Refresh ST's lorebook list
-            if (typeof loadWorldInfoList === 'function') {
-                loadWorldInfoList();
-            }
+            await updateWorldInfoList();
             
             CarrotDebug.repo(`✅ Pack updated successfully: ${localPack.displayName}`);
             return true;
@@ -922,16 +927,17 @@ export class CarrotPackManager {
     // Load locally installed packs
     loadLocalPacks() {
         const settings = extension_settings[extensionName] || {};
-        const packs = settings.packs || {};
-        
+        // Every install path writes to installedPacks (and never sets an `installed`
+        // flag) — this used to read the never-written `packs` key, so installed
+        // packs were forgotten on every page load.
+        const packs = settings.installedPacks || {};
+
         this.localPacks.clear();
-        
+
         for (const [packName, packData] of Object.entries(packs)) {
-            if (packData.installed) {
-                this.localPacks.set(packName, packData);
-            }
+            this.localPacks.set(packName, packData);
         }
-        
+
         CarrotDebug.repo(`📁 Loaded ${this.localPacks.size} local packs`);
     }
 }

--- a/repository-manager.js
+++ b/repository-manager.js
@@ -4,7 +4,11 @@
 // Extracted from index.js for better modularity
 // =============================================================================
 
+import { saveSettingsDebounced } from '../../../../script.js';
 import { extension_settings } from '../../../extensions.js';
+import { escapeHtml } from '../../../utils.js';
+import { CarrotDebug } from './debugger.js';
+import { CarrotTemplateManager } from './sheet-generator.js';
 import { EXTENSION_NAME } from './carrot-state.js';
 import {
     currentRepoView,
@@ -31,6 +35,30 @@ export function initializeRepositoryManager(showPopupFn, closePopupFn, scanFn, u
     closeCarrotPopup = closePopupFn;
     scanSelectedLorebooks = scanFn;
     updateStatusPanels = updatePanelsFn;
+    bindRepositoryManagerEvents();
+}
+
+// Delegated click handlers for the repository browser, bound once on the persistent
+// popup container. Replaces inline onclick="...('${name}')" handlers, whose
+// interpolated values (repo/character names, tag categories/values) come from
+// parsed lorebook content and were previously escaped only for single quotes —
+// never for `"` or `<` — letting a crafted pack name/tag break out of the
+// attribute or inject markup.
+function bindRepositoryManagerEvents() {
+    const $container = $('#carrot-popup-container');
+
+    $container.off('click', '.carrot-repo-file-item[data-repo-item]').on('click', '.carrot-repo-file-item[data-repo-item]', function() {
+        selectRepository($(this).attr('data-repo'));
+    });
+    $container.off('dblclick', '.carrot-repo-file-item[data-repo-item]').on('dblclick', '.carrot-repo-file-item[data-repo-item]', function() {
+        navigateToRepository($(this).attr('data-repo'));
+    });
+    $container.off('click', '.carrot-repo-file-item[data-char-item]').on('click', '.carrot-repo-file-item[data-char-item]', function() {
+        navigateToCharacter($(this).attr('data-char-name'), $(this).attr('data-repo'));
+    });
+    $container.off('click', '.carrot-repo-breadcrumb-item[data-repo-nav]').on('click', '.carrot-repo-breadcrumb-item[data-repo-nav]', function() {
+        navigateToRepository($(this).attr('data-repo'));
+    });
 }
 
 // Repository manager main entry point
@@ -219,7 +247,7 @@ function renderRepositoryBreadcrumb() {
             </span>
             <i class="fa-solid fa-chevron-right carrot-repo-breadcrumb-sep"></i>
             <span class="carrot-repo-breadcrumb-item carrot-repo-breadcrumb-active">
-                ${selectedRepository}
+                ${escapeHtml(selectedRepository)}
             </span>
         `;
     } else if (currentRepoView === 'character') {
@@ -228,12 +256,12 @@ function renderRepositoryBreadcrumb() {
                 <i class="fa-solid fa-folder"></i> Repositories
             </span>
             <i class="fa-solid fa-chevron-right carrot-repo-breadcrumb-sep"></i>
-            <span class="carrot-repo-breadcrumb-item carrot-clickable" onclick="navigateToRepository('${selectedRepository}')">
-                ${selectedRepository}
+            <span class="carrot-repo-breadcrumb-item carrot-clickable" data-repo-nav data-repo="${escapeHtml(selectedRepository)}">
+                ${escapeHtml(selectedRepository)}
             </span>
             <i class="fa-solid fa-chevron-right carrot-repo-breadcrumb-sep"></i>
             <span class="carrot-repo-breadcrumb-item carrot-repo-breadcrumb-active">
-                ${selectedCharacter}
+                ${escapeHtml(selectedCharacter)}
             </span>
         `;
     }
@@ -267,7 +295,7 @@ function renderRepositoryPreview() {
         let characterListHTML = characters.slice(0, 10).map(c => {
             const tagCount = c.tags ? (c.tags instanceof Map ? c.tags.size : Object.keys(c.tags).length) : 0;
             const isActive = c.isActive ? '🟢 ' : '';
-            return `<li>${isActive}<strong>${c.name || 'Unknown'}</strong> - ${tagCount} tags</li>`;
+            return `<li>${isActive}<strong>${escapeHtml(c.name || 'Unknown')}</strong> - ${tagCount} tags</li>`;
         }).join('');
 
         if (characters.length > 10) {
@@ -276,7 +304,7 @@ function renderRepositoryPreview() {
 
         return `
             <div class="carrot-repo-preview-info">
-                <h4><i class="fa-solid fa-folder"></i> ${selectedRepository}</h4>
+                <h4><i class="fa-solid fa-folder"></i> ${escapeHtml(selectedRepository)}</h4>
                 <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 16px 0; padding: 12px; background: rgba(0,0,0,0.2); border-radius: 8px;">
                     <div>
                         <div style="font-size: 24px; font-weight: 600; color: var(--SmartThemeEmColor);">${characters.length}</div>
@@ -382,14 +410,13 @@ function renderRepositoryList() {
         const characters = Array.from(scannedCharacters.values()).filter(c => c.source === repoName);
         html += `
             <div class="carrot-repo-file-item carrot-clickable"
-                 onclick="CarrotKernel.selectRepository('${repoName.replace(/'/g, "\\'")}')"
-                 ondblclick="CarrotKernel.navigateToRepository('${repoName.replace(/'/g, "\\'")}')"
-                 data-repo="${repoName}">
+                 data-repo-item
+                 data-repo="${escapeHtml(repoName)}">
                 <div class="carrot-repo-file-icon">
                     <i class="fa-solid fa-folder"></i>
                 </div>
                 <div class="carrot-repo-file-info">
-                    <div class="carrot-repo-file-name">${repoName}</div>
+                    <div class="carrot-repo-file-name">${escapeHtml(repoName)}</div>
                     <div class="carrot-repo-file-meta">${characters.length} ${characters.length === 1 ? 'character' : 'characters'}</div>
                 </div>
             </div>
@@ -419,13 +446,13 @@ function renderCharacterList() {
         const tagCount = char.tags ? (char.tags instanceof Map ? char.tags.size : Object.keys(char.tags).length) : 0;
         const isActive = char.isActive;
         html += `
-            <div class="carrot-repo-file-item carrot-clickable" onclick="CarrotKernel.navigateToCharacter('${char.name.replace(/'/g, "\\'")}', '${selectedRepository.replace(/'/g, "\\'")}')">
+            <div class="carrot-repo-file-item carrot-clickable" data-char-item data-char-name="${escapeHtml(char.name || '')}" data-repo="${escapeHtml(selectedRepository)}">
                 <div class="carrot-repo-file-icon">
                     <i class="fa-solid fa-user"></i>
                 </div>
                 <div class="carrot-repo-file-info">
                     <div class="carrot-repo-file-name">
-                        ${isActive ? '<span class="carrot-repo-status-active">🟢</span> ' : ''}${char.name || 'Unknown'}
+                        ${isActive ? '<span class="carrot-repo-status-active">🟢</span> ' : ''}${escapeHtml(char.name || 'Unknown')}
                     </div>
                     <div class="carrot-repo-file-meta">${tagCount} ${tagCount === 1 ? 'tag' : 'tags'}</div>
                 </div>
@@ -453,7 +480,7 @@ function renderCharacterDetails() {
     // Character header with stats
     let html = `
         <div class="carrot-repo-summary">
-            <p><i class="fa-solid fa-user"></i> ${char.name || 'Unknown'} • ${tags.length} ${tags.length === 1 ? 'category' : 'categories'}</p>
+            <p><i class="fa-solid fa-user"></i> ${escapeHtml(char.name || 'Unknown')} • ${tags.length} ${tags.length === 1 ? 'category' : 'categories'}</p>
         </div>
         <div style="margin: 16px 0; padding: 16px; background: rgba(0,0,0,0.2); border-radius: 8px;">
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
@@ -468,7 +495,7 @@ function renderCharacterDetails() {
             </div>
             <div style="margin-top: 12px; padding-top: 12px; border-top: 1px solid rgba(255,255,255,0.1);">
                 <div style="font-size: 11px; opacity: 0.7;">Source Repository</div>
-                <div style="font-size: 13px; font-weight: 500;">${char.source}</div>
+                <div style="font-size: 13px; font-weight: 500;">${escapeHtml(char.source || '')}</div>
             </div>
         </div>
     `;
@@ -484,12 +511,12 @@ function renderCharacterDetails() {
                     <i class="fa-solid fa-tag"></i>
                 </div>
                 <div class="carrot-repo-file-info">
-                    <div class="carrot-repo-file-name">${category}</div>
+                    <div class="carrot-repo-file-name">${escapeHtml(category)}</div>
                     <div class="carrot-repo-file-meta">${valueCount} ${valueCount === 1 ? 'tag' : 'tags'}</div>
                 </div>
             </div>
             <div style="padding: 8px 16px 16px 56px; display: flex; flex-wrap: wrap; gap: 6px;">
-                ${valuesArray.map(val => `<span style="display: inline-block; padding: 4px 10px; background: rgba(102, 126, 234, 0.2); border: 1px solid rgba(102, 126, 234, 0.4); border-radius: 12px; font-size: 12px; color: #a5b4fc;">${val}</span>`).join('')}
+                ${valuesArray.map(val => `<span style="display: inline-block; padding: 4px 10px; background: rgba(102, 126, 234, 0.2); border: 1px solid rgba(102, 126, 234, 0.4); border-radius: 12px; font-size: 12px; color: #a5b4fc;">${escapeHtml(String(val))}</span>`).join('')}
             </div>
         `;
     });
@@ -657,13 +684,13 @@ function showCharacterDetails(characterName) {
     const tags = char.tags instanceof Map ? Array.from(char.tags.entries()) : Object.entries(char.tags || {});
     let tagsHTML = '';
     tags.forEach(([key, value]) => {
-        tagsHTML += `<div class="carrot-tag-item"><strong>${key}:</strong> ${value}</div>`;
+        tagsHTML += `<div class="carrot-tag-item"><strong>${escapeHtml(key)}:</strong> ${escapeHtml(String(value))}</div>`;
     });
 
     const detailsHTML = `
         <div style="padding: 20px; max-width: 800px;">
-            <h2 style="margin-bottom: 16px;">🎭 ${characterName}</h2>
-            <p><strong>Source:</strong> ${char.source}</p>
+            <h2 style="margin-bottom: 16px;">🎭 ${escapeHtml(characterName)}</h2>
+            <p><strong>Source:</strong> ${escapeHtml(char.source || '')}</p>
             <h3 style="margin-top: 24px; margin-bottom: 12px;">Tags (${tags.length})</h3>
             <div style="display: grid; gap: 8px;">
                 ${tagsHTML}

--- a/sheet-generator.js
+++ b/sheet-generator.js
@@ -5,7 +5,7 @@
 
 import { CarrotDebug } from './debugger.js';
 import { saveSettingsDebounced } from '../../../../script.js';
-import { extension_settings, writeExtensionField } from '../../../extensions.js';
+import { extension_settings } from '../../../extensions.js';
 import { loadWorldInfo } from '../../../world-info.js';
 import {
     scannedCharacters,
@@ -47,7 +47,7 @@ async function generateFullSheet(characterName, charData) {
             tags: charData.tags
         };
 
-        return await CarrotTemplateManager.processTemplate(currentTemplate.content, templateData);
+        return await CarrotTemplateManager.processTemplate(currentTemplate, templateData);
     }
     
     // Fallback to default format
@@ -77,7 +77,7 @@ async function generateTagSheet(characterName, charData) {
             tags: charData.tags
         };
 
-        return await CarrotTemplateManager.processTemplate(currentTemplate.content, templateData);
+        return await CarrotTemplateManager.processTemplate(currentTemplate, templateData);
     }
     
     // Fallback to BunnymoTags format
@@ -161,7 +161,7 @@ async function generateQuickSheet(characterName, charData) {
             tags: charData.tags
         };
 
-        return await CarrotTemplateManager.processTemplate(currentTemplate.content, templateData);
+        return await CarrotTemplateManager.processTemplate(currentTemplate, templateData);
     }
     
     // Fallback to default format
@@ -850,14 +850,13 @@ const CarrotTemplateManager = {
 
     saveSettings(immediate = false) {
         if (immediate) {
-            // Force immediate save for critical operations like template saving
-            // First ensure the entire extension settings object is saved
+            // Force immediate save for critical operations like template saving.
+            // writeExtensionField is for per-character data (it looks up
+            // context.characters[characterId]) — 'CarrotKernel' is never a valid
+            // character id, so it was always a silent no-op. Templates are global
+            // extension settings; saveSettingsDebounced() is the real persistence.
             if (typeof saveSettingsDebounced === 'function') {
                 saveSettingsDebounced();
-            }
-            // Also try to force immediate write
-            if (typeof writeExtensionField === 'function') {
-                writeExtensionField(extensionName, 'templates', extension_settings[extensionName]?.templates || {});
             }
         } else {
             saveSettingsDebounced();
@@ -1130,13 +1129,13 @@ const CarrotTemplateManager = {
 
             // Individual pack macros - DERE
             'DERE_OPTIONS': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('DERE', 'tags');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('DERE', 'tags');
                 if (options.length === 0) return 'No DERE options found in selected lorebooks';
                 return `**DERE Pack Options:**\n${options.map(tag => `- ${tag}`).join('\n')}`;
             },
 
             'DERE_OPTIONS_DETAILED': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('DERE', 'tags+content');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('DERE', 'tags+content');
                 if (options.length === 0) return 'No DERE options found in selected lorebooks';
                 let output = '**DERE Pack Options (with descriptions):**\n\n';
                 options.forEach(opt => {
@@ -1147,13 +1146,13 @@ const CarrotTemplateManager = {
 
             // MBTI Pack
             'MBTI_OPTIONS': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('MBTI', 'tags');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('MBTI', 'tags');
                 if (options.length === 0) return 'No MBTI options found in selected lorebooks';
                 return `**MBTI Pack Options:**\n${options.map(tag => `- ${tag}`).join('\n')}`;
             },
 
             'MBTI_OPTIONS_DETAILED': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('MBTI', 'tags+content');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('MBTI', 'tags+content');
                 if (options.length === 0) return 'No MBTI options found in selected lorebooks';
                 let output = '**MBTI Pack Options (with descriptions):**\n\n';
                 options.forEach(opt => {
@@ -1164,13 +1163,13 @@ const CarrotTemplateManager = {
 
             // TRAIT Pack
             'TRAIT_OPTIONS': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('TRAIT', 'tags');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('TRAIT', 'tags');
                 if (options.length === 0) return 'No TRAIT options found in selected lorebooks';
                 return `**TRAIT Pack Options:**\n${options.map(tag => `- ${tag}`).join('\n')}`;
             },
 
             'TRAIT_OPTIONS_DETAILED': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('TRAIT', 'tags+content');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('TRAIT', 'tags+content');
                 if (options.length === 0) return 'No TRAIT options found in selected lorebooks';
                 let output = '**TRAIT Pack Options (with descriptions):**\n\n';
                 options.forEach(opt => {
@@ -1181,13 +1180,13 @@ const CarrotTemplateManager = {
 
             // LINGUISTICS Pack
             'LINGUISTICS_OPTIONS': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('LINGUISTICS', 'tags');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('LINGUISTICS', 'tags');
                 if (options.length === 0) return 'No LINGUISTICS options found in selected lorebooks';
                 return `**LINGUISTICS Pack Options:**\n${options.map(tag => `- ${tag}`).join('\n')}`;
             },
 
             'LINGUISTICS_OPTIONS_DETAILED': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('LINGUISTICS', 'tags+content');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('LINGUISTICS', 'tags+content');
                 if (options.length === 0) return 'No LINGUISTICS options found in selected lorebooks';
                 let output = '**LINGUISTICS Pack Options (with descriptions):**\n\n';
                 options.forEach(opt => {
@@ -1198,13 +1197,13 @@ const CarrotTemplateManager = {
 
             // SPECIES Pack
             'SPECIES_OPTIONS': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('SPECIES', 'tags');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('SPECIES', 'tags');
                 if (options.length === 0) return 'No SPECIES options found in selected lorebooks';
                 return `**SPECIES Pack Options:**\n${options.map(tag => `- ${tag}`).join('\n')}`;
             },
 
             'SPECIES_OPTIONS_DETAILED': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('SPECIES', 'tags+content');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('SPECIES', 'tags+content');
                 if (options.length === 0) return 'No SPECIES options found in selected lorebooks';
                 let output = '**SPECIES Pack Options (with descriptions):**\n\n';
                 options.forEach(opt => {
@@ -1215,13 +1214,13 @@ const CarrotTemplateManager = {
 
             // GENRE Pack
             'GENRE_OPTIONS': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('GENRE', 'tags');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('GENRE', 'tags');
                 if (options.length === 0) return 'No GENRE options found in selected lorebooks';
                 return `**GENRE Pack Options:**\n${options.map(tag => `- ${tag}`).join('\n')}`;
             },
 
             'GENRE_OPTIONS_DETAILED': async () => {
-                const options = await CarrotTemplateManager.macroProcessors['BUNNYMO_PACK_TAGS'].getBunnyMoPackOptions('GENRE', 'tags+content');
+                const options = await CarrotTemplateManager.macroProcessors.getBunnyMoPackOptions('GENRE', 'tags+content');
                 if (options.length === 0) return 'No GENRE options found in selected lorebooks';
                 let output = '**GENRE Pack Options (with descriptions):**\n\n';
                 options.forEach(opt => {
@@ -1484,6 +1483,11 @@ ${stats.totalCharacters === 0 ? '⚠️ No characters found - scan lorebooks fir
         // Replace each macro with processed data
         // CRITICAL: Await all processors since some are async
         for (const [macro, processor] of Object.entries(this.macroProcessors)) {
+            // getBunnyMoPackOptions is a helper method used by the *_OPTIONS
+            // processors above (called with pack-prefix/detail-level args), not a
+            // standalone template macro — skip it here so it isn't surfaced as a
+            // bogus {{getBunnyMoPackOptions}} macro card.
+            if (macro === 'getBunnyMoPackOptions') continue;
             const placeholder = `{{${macro}}}`;
             if (processedContent.includes(placeholder)) {
                 const replacement = await processor();  // ✅ FIXED: Await processor

--- a/template-editor.js
+++ b/template-editor.js
@@ -380,6 +380,9 @@ export class CarrotTemplatePromptEditInterface {
             // Get actual functional CarrotKernel macros - use direct reference since we're in the same file
             if (CarrotTemplateManager && CarrotTemplateManager.macroProcessors) {
                 Object.keys(CarrotTemplateManager.macroProcessors).forEach(macro => {
+                    // Helper method for the *_OPTIONS processors, not a standalone
+                    // macro — don't surface it as a bogus {{getBunnyMoPackOptions}} card.
+                    if (macro === 'getBunnyMoPackOptions') return;
                     priorityMacros.push(macro);
                 });
             } else {
@@ -872,6 +875,9 @@ Most common categories:<br/>
         // Get ALL functional macros from CarrotTemplateManager (direct reference)
         if (CarrotTemplateManager && CarrotTemplateManager.macroProcessors) {
             Object.keys(CarrotTemplateManager.macroProcessors).forEach(macro => {
+                // Helper method for the *_OPTIONS processors, not a standalone
+                // macro — don't surface it as a bogus {{getBunnyMoPackOptions}} card.
+                if (macro === 'getBunnyMoPackOptions') return;
                 allMacros.push(macro);
             });
         }
@@ -929,9 +935,11 @@ Most common categories:<br/>
         }
     }
     
-    previewMacro(macro) {
-        // Get the current value from our macro processing system
-        const processedContent = CarrotTemplateManager.processMacros(`{{${macro.name}}}`);
+    async previewMacro(macro) {
+        // Get the current value from our macro processing system. processMacros is
+        // async (it awaits each processor internally), so this must be awaited too —
+        // otherwise the alert renders the literal text "[object Promise]".
+        const processedContent = await CarrotTemplateManager.processMacros(`{{${macro.name}}}`);
         alert(`Macro Preview: ${macro.name}\n\nOutput:\n${processedContent}`);
     }
     
@@ -1404,15 +1412,17 @@ Most common categories:<br/>
         return variables;
     }
     
-    preview_current_template() {
+    async preview_current_template() {
         const content = this.$prompt.val();
         if (!content) {
             toastr.warning('No content to preview');
             return;
         }
-        
-        // Use CarrotKernel's real macro processing system
-        let preview = CarrotTemplateManager.processMacros(content);
+
+        // Use CarrotKernel's real macro processing system. processMacros is async
+        // (it awaits each processor internally), so this must be awaited too —
+        // otherwise the popup renders the literal text "[object Promise]".
+        let preview = await CarrotTemplateManager.processMacros(content);
         
         // Show preview in CarrotKernel popup
         const previewHtml = `

--- a/worldbook-tracker.js
+++ b/worldbook-tracker.js
@@ -1277,14 +1277,25 @@ const getPositionName = (position) => {
         3: 'Author\'s Note Bottom',
         4: 'At Depth',
         5: 'Extension Module Top',
-        6: 'Extension Module Bottom'
+        6: 'Extension Module Bottom',
+        7: 'Outlet'
     };
     return positions[position] || `Unknown (${position})`;
 };
 
 // 🛡️ SAFER ST WORLDBOOK INTEGRATION - NO GLOBAL PROTOTYPE PATCHING
-const entrySourceTracker = new Map(); // uid -> source info
+// Keyed by `${entry.world}§§§${entry.uid}` (matching updateBadge's key and ST's own
+// WorldInfoBuffer.externalActivations convention) — World Info uids are only unique
+// per lorebook file (getFreeWorldEntryUid restarts from 0 in every world file), so
+// keying by uid alone lets entries from different books collide and overwrite
+// each other's source info.
+const entrySourceTracker = new Map(); // `${world}§§§${uid}` -> source info
 const nativeTriggerReasons = new Map(); // uid -> native ST trigger reason
+
+// Panel control buttons — created once during panel construction, re-appended by
+// updatePanel() after each innerHTML wipe, so they must live at module scope.
+let debugToggle = null;
+let clearHighlightsButton = null;
 
 // 🎯 PRECISE ST NATIVE LOG INTERCEPTION - CAPTURE EXACT TRIGGER REASONS
 const nativeSTTriggerReasons = new Map(); // uid -> {reason, timestamp}
@@ -1355,7 +1366,7 @@ const classifyTriggerReasonFromEntry = (entry, contextData = {}) => {
     }
 
     // Check source tracker for vector entries
-    const sourceInfo = entrySourceTracker.get(entry.uid);
+    const sourceInfo = entrySourceTracker.get(`${entry.world}§§§${entry.uid}`);
     if (sourceInfo && sourceInfo.source === 'WORLDINFO_FORCE_ACTIVATE') {
         return 'vector';
     }
@@ -1709,7 +1720,16 @@ const getMessageSourceIcon = (messageSource) => {
 };
 
 // Get device-specific ID for per-device settings
+let trackerInitialized = false;
+
 const init = () => {
+    // Guard against duplicate DOM elements, MutationObservers, and eventSource
+    // listeners if init() is ever called more than once (e.g. once enable() below
+    // is made self-initialising for the "was never init()'d" case).
+    if (trackerInitialized) {
+        return;
+    }
+    trackerInitialized = true;
 
     const trigger = document.createElement('div');
     trigger.classList.add('ck-trigger');
@@ -2140,8 +2160,22 @@ function disableRepositionMode() {
             }
         });
 
+        // Clears any trigger-word highlight markup in the panel/chat. No dedicated
+        // highlighting pass exists yet elsewhere in this file — this keeps the
+        // clear-highlights button a real, working no-op today (rather than calling
+        // a function that doesn't exist) and will pick up real highlight elements
+        // automatically if a highlighting pass is added later.
+        const clearTriggerHighlights = () => {
+            document.querySelectorAll('.ck-trigger-highlight').forEach(el => {
+                el.classList.remove('ck-trigger-highlight');
+            });
+            panel.querySelectorAll('.ck-entry--highlighted').forEach(el => {
+                el.classList.remove('ck-entry--highlighted');
+            });
+        };
+
         // Add debug toggle button at the top of the panel
-        const debugToggle = document.createElement('div'); {
+        debugToggle = document.createElement('div');
             debugToggle.classList.add('ck-debug-toggle');
             debugToggle.textContent = '🔍';
             debugToggle.title = 'Click to toggle debug mode - shows what triggered each entry';
@@ -2178,7 +2212,7 @@ function disableRepositionMode() {
             }
 
             // Add clear highlights button
-            const clearHighlightsButton = document.createElement('button');
+            clearHighlightsButton = document.createElement('button');
             clearHighlightsButton.classList.add('ck-clear-highlights');
             clearHighlightsButton.style.cssText = `
                 position: absolute;
@@ -2216,7 +2250,8 @@ function disableRepositionMode() {
                 clearHighlightsButton.style.borderColor = 'rgba(231, 76, 60, 0.3)';
             });
 
-        }
+        // Appended by updatePanel() (called below via updatePanel([])), which
+        // re-appends them on every render since panel.innerHTML gets wiped there.
 
         document.body.append(panel);
     }
@@ -2484,9 +2519,17 @@ function disableRepositionMode() {
 
     eventSource.on(event_types.WORLD_INFO_ACTIVATED, async(entryList)=>{
 
-        // Track all entries from this event as standard activation
+        // Track all entries from this event as standard activation. Don't stamp over
+        // an entry that WORLDINFO_FORCE_ACTIVATE already classified as a vector hit
+        // this generation — otherwise classifyTriggerReasonFromEntry's source-tracker
+        // check below can never see 'WORLDINFO_FORCE_ACTIVATE' by the time it runs.
         entryList.forEach(entry => {
-            entrySourceTracker.set(entry.uid, {
+            const key = `${entry.world}§§§${entry.uid}`;
+            const existing = entrySourceTracker.get(key);
+            if (existing && existing.source === 'WORLDINFO_FORCE_ACTIVATE') {
+                return;
+            }
+            entrySourceTracker.set(key, {
                 source: 'WORLD_INFO_ACTIVATED',
                 timestamp: Date.now(),
                 triggerType: 'standard'
@@ -2531,7 +2574,7 @@ function disableRepositionMode() {
 
         // Track all entries from this event as vector activation
         entryList.forEach(entry => {
-            entrySourceTracker.set(entry.uid, {
+            entrySourceTracker.set(`${entry.world}§§§${entry.uid}`, {
                 source: 'WORLDINFO_FORCE_ACTIVATE',
                 timestamp: Date.now(),
                 triggerType: 'vector'
@@ -2553,6 +2596,21 @@ function disableRepositionMode() {
 
     const updatePanel = (entryList, newChat = false) => {
         panel.innerHTML = '';
+
+        // Reset potato-mode styling unconditionally. The potato branch below sets
+        // panel.classList and panel.style.cssText wholesale but never reverts them,
+        // so a single potato-mode round trip otherwise leaves the panel permanently
+        // stuck at the potato layout even after the setting is turned back off.
+        // Removing the class here also trips the MutationObserver below, which
+        // re-applies real geometry via positionPanel() once the DOM settles.
+        panel.classList.remove('ck-potato-mode');
+        panel.style.cssText = '';
+
+        // Re-append the debug toggle and clear-highlights buttons — they're stable,
+        // created once in init(), but panel.innerHTML above wipes them out along
+        // with everything else on every render.
+        if (debugToggle) panel.appendChild(debugToggle);
+        if (clearHighlightsButton) panel.appendChild(clearHighlightsButton);
 
         // Show empty state if no entries
         if (!entryList || entryList.length === 0) {
@@ -2759,9 +2817,19 @@ function disableRepositionMode() {
             sizeControls.appendChild(btn);
         });
 
-        // Set default active state (compact mode)
-        sizeButtons.compact.classList.add('ck-size-toggle--active');
-        panel.classList.add('ck-panel--compact');
+        // Restore whichever size mode the user last selected instead of hard-coding
+        // compact on every rebuild. panel.innerHTML is cleared above, but `panel`
+        // itself is a single element reused across calls, so its own classList
+        // (and dataset) survive rebuilds — read the prior mode off it here.
+        const wasDetailed = panel.dataset.ckSizeModeSet === 'true' && !panel.classList.contains('ck-panel--compact');
+        panel.dataset.ckSizeModeSet = 'true';
+
+        if (wasDetailed) {
+            sizeButtons.detailed.classList.add('ck-size-toggle--active');
+        } else {
+            sizeButtons.compact.classList.add('ck-size-toggle--active');
+            panel.classList.add('ck-panel--compact');
+        }
 
         header.appendChild(icon);
         header.appendChild(title);
@@ -3215,7 +3283,8 @@ function disableRepositionMode() {
                         3: '↓ Author\'s Note Bottom',
                         4: '📍 At Depth Position',
                         5: '↑ Extension Module Top',
-                        6: '↓ Extension Module Bottom'
+                        6: '↓ Extension Module Bottom',
+                        7: '🔌 Outlet'
                     };
                     const positionLabel = positionLabels[entry.position] || `Position ${entry.position}`;
                     debugLines.push(`📍 <strong>Insertion Position:</strong> ${positionLabel} - where content is inserted in prompt`);
@@ -3314,6 +3383,12 @@ let trackerElements = {
 };
 
 const enable = () => {
+    // Self-initialise if the tracker was never init()'d (e.g. the extension started
+    // disabled, so index.js's only init() call site was skipped) — otherwise all four
+    // guards below fail and enable() is a permanent no-op until a full page reload.
+    if (!trackerElements.trigger) {
+        init();
+    }
     if (trackerElements.trigger) {
         trackerElements.trigger.style.display = 'block';
     }


### PR DESCRIPTION
Hi! While doing a compatibility pass over the extensions against **SillyTavern staging (1.18.0, `380e31e`)**, I found a fair number of bugs in CarrotKernel and fixed them. Every finding was confirmed against the staging source before I changed anything, and the result was verified in a live ST instance.

This is a big PR because the audit was broad — very happy to split it into smaller pieces (per-file or per-severity), drop anything you disagree with, or hand back just the findings if you'd rather fix them your own way.

---

## Critical

**The in-chat vectorize button never appears, and auto-vectorize never runs** — `fullsheet-rag.js:3648` and `:4008`
```js
const message = chat.find(msg => msg.index === messageId);
if (!message || !message.mes) { return; }
```
ST chat messages have no `index` property — staging derives it positionally (`script.js:2537`, `const index = chat.indexOf(mes)`), and `grep -n "\.index = " public/script.js` finds nothing that ever sets it. So the lookup always returns `undefined` and both functions bail immediately. `addRAGButtonToMessage` is called from the `CHARACTER_MESSAGE_RENDERED` handler with ST's numeric `chat_id`, so the purple "Vectorize Fullsheet" button has never rendered, and `autoVectorizeMessage` never vectorizes anything despite `autoVectorize` defaulting to `true`.

Worth noting the extension's own `addRAGButtonsToAllMessages` already does it right (`chat.forEach((message, index) => addRAGButtonToMessage(index))`), so this looks like a copy that drifted. Same defect in `index.js:2982` for persistent BunnyMoTags.

**Editing a chunk permanently destroys its embedding** — `fullsheet-rag.js:477`, `:501`
`apiDeleteVectorHashes` / `apiDeleteCollection` call `response.json()` on `/api/vector/delete` and `/api/vector/purge`, but those endpoints reply `res.sendStatus(200)` — the body is the string `"OK"` with `text/plain` (`src/endpoints/vectors.js:547-563`). So they always throw `SyntaxError` **after** the server has already deleted the vectors, and in `updateChunksInLibrary` the `apiInsertVectorItems` re-insert on the next line never runs.

User-visible: edit a chunk's text in the Chunk Visualizer, hit Save, get `Failed to re-vectorize chunks: Unexpected token 'O', "OK" is not valid JSON`. The chunk is still listed in the library, but its embedding is gone from vectra and it's silently unretrievable until the whole collection is rebuilt. (ST's own vectors extension never parses these responses; `apiInsertVectorItems` in this same file already gets it right.)

## High

- **Re-vectorizing always duplicates** (`fullsheet-rag.js:3820`) — `/api/vector/list` returns a flat `number[]` (`vectors.js:344-350`), but the dedup set is built with `savedHashes.map(h => h.hash)`, so it's `Set{undefined}` and nothing ever matches. Every chunk is re-embedded on every run (real cost on paid providers), and because `upsertItem` is called with no `id`, vectra mints a fresh UUID and **appends** rather than replacing — the index grows unbounded and topK fills with duplicates.
- **The RAG interceptor runs twice per turn** (`fullsheet-rag.js:3968`) — it's registered both via the manifest's `generate_interceptor` and as a `GENERATION_STARTED` listener. The event path passes completely different arguments than the signature expects (`emit(GENERATION_STARTED, type, {...}, dryRun)` vs `(chat, contextSize, abort, type)`), which also makes the `type === 'quiet'` guard dead — so quiet/background generations and dry runs both ran a full RAG pass. Removed the event registration; the manifest hook is the correct one.
- **The injected prompt arrives as one unbroken line** (`fullsheet-rag.js:3528`, `:3530`) — the joins use `'\\n'` (backslash + `n`), not a newline, so section headers don't render as headers and the model sees literal `\n` sequences. There's also a stray U+FFFD as the header separator on `:3501`.
- **Deleted chunks come back** (`fullsheet-rag.js:528`) — `updateChunksInLibrary` only writes the chunks still present and never diffs against what's stored, so a deleted chunk survives the save and keeps being retrieved. `purgeOrphanedVectors` already existed for this but was never called from that path.
- **Pack installs always fail** (`index.js:4537`, `pack-manager.js` ×3) — these POST JSON to `/api/worldinfo/import`, which requires a multipart upload (`if (!request.file) return response.sendStatus(400)`, `src/endpoints/worldinfo.js:99`) and also needs the CSRF token that `getRequestHeaders()` supplies. Switched to `/api/worldinfo/edit`, which accepts the exact `{ name, data }` shape these call sites already build — and the name is now sent without the `.json` suffix, since that endpoint appends it itself (otherwise you'd get `Foo.json.json`).
- **Installed packs are forgotten on every reload** (`pack-manager.js:925`) — `loadLocalPacks()` reads `settings.packs` and requires `packData.installed`, but every install path writes `settings.installedPacks` and never sets that flag. So the Pack Manager reports 0 installed after a refresh, and update checking iterates an empty map.
- **Character Cards mode throws on first render** (`card-renderer.js:10`) — the module uses `extension_settings`, `extensionName`, `findCharacterByName` and `refreshTabContent` without importing or receiving any of them, so every exported function throws `ReferenceError` on its first line. `renderAsCards` also `.join('')`s DOM elements, producing `[object HTMLDivElement]`. Wired up via the same initializer-setter pattern `sheet-generator.js` and `repository-manager.js` already use.
- **Repository Manager won't open if any stale repo exists** (`repository-manager.js:77`) — `cleanupStaleRepositories()` calls `saveSettingsDebounced()`, which isn't imported and isn't a global, so it throws before `renderRepositoryManager()` and the popup silently never appears.
- **All twelve `{{*_OPTIONS}}` macros throw** (`sheet-generator.js:1133` and 11 more) — they read `getBunnyMoPackOptions` off the `BUNNYMO_PACK_TAGS` *function* instead of as a sibling method on `macroProcessors`. `processMacros` awaits with no try/catch, so the rejection propagates and **all** character-data injection stops for that turn. These are listed in the Template Editor's macro picker, so they're reachable from the UI.
- **Three sheet generators pass a string where the template object is expected** (`sheet-generator.js:50/80/164`) — `processTemplate(currentTemplate.content, ...)` then reads `template.content` off a string, so `{{FULLSHEET_FORMAT}}` and friends always expand to `''` silently.
- **`updateWorldInfoList` was guarded on a symbol that doesn't exist** (`index.js:1046/1131/4597`, `pack-manager.js` ×3) — `typeof loadWorldInfoList === 'function'` is permanently false (no such export in staging under any name; the real one is `updateWorldInfoList`, already imported). So `world_names` was never refreshed after writing a lorebook — new books didn't show in the WI dropdown until reload, and `backupLorebook()`'s "already backed up" check stayed stale, letting a second toggle overwrite a pristine backup with already-wrapped content.

## Medium

- **A whole block of Chunk Visualizer handlers lived in `index.js`** (`index.js:8433-8686`, `:8844`) referencing `modifiedChunks` / `renderChunks` / `getSearchTerm` / `hasUnsavedChanges` — all module-private to `chunk-visualizer.js`. Every link-checkbox toggle and the entire "Add Chunk" button threw `ReferenceError`. Moved into the module where that state is in scope. While doing this I found 7 of the listed selectors match no markup anywhere and two called functions that don't exist, so those were removed rather than carried forward — happy to restore them if that UI is planned.
- **`fullsheetAPI` was built from a hard-coded whitelist** (`index.js:8138`) omitting `apiInsertVectorItems`, `deleteEntireCollection` and `purgeOrphanedVectors`, so re-vectorize failed for every collection while still reporting success and hiding the provider-mismatch warning — leaving RAG silently querying the old provider's embeddings forever.
- **"Link to World Info" override never fired** (`index.js:9667`) — it compares `$(this).val()` against `'set_character_world'`, but that string is the `<option>`'s **id**; staging matches on the id too (`script.js:12324`). Also the handler was delegated on `document` while ST's is bound directly, so ST always ran first.
- **Entry source tracking collided across lorebooks** (`worldbook-tracker.js:1286`) — keyed by `uid` alone, but WI uids restart from 0 in every world file (`getFreeWorldEntryUid`). ST itself composite-keys these (`WorldInfoBuffer.externalActivations`, `world-info.js:1025`), and the badge code in this same file already used `world§§§uid`.
- **Primary lorebook written into `extraBooks`** (`lorebook-connector.js:711`) — ST treats `extensions.world` and `extraBooks` as disjoint, so the primary book showed up selected in the auxiliary multi-select too.
- **Baby Bunny**: `characterRepoBooks` and `createNewWorldInfo` were used without being imported (every single-character archive threw after writing the lorebook but before activating it; every batch "new lorebook" install failed silently with debug logging off); global activation wrote `selected_world_info` but never `world_info.globalSelect`, so it vanished on reload; batch validation ran *after* the popup was destroyed, discarding the user's whole configuration with no way back and leaving the promise unresolved; and the save "verification" re-read `saveWorldInfo`'s own synchronous cache, so it always passed without confirming anything.
- **Repository Manager HTML injection** (`repository-manager.js:492` and others) — character names, tag values and repo names from downloaded packs were interpolated raw into markup that's assigned via `.html()`, with only single quotes escaped. Now escaped via ST's `escapeHtml`, with the data-carrying inline handlers converted to `data-*` + delegated listeners.
- **GitHub rate-limit path could hang for up to an hour** (`pack-manager.js:81`) — when the unauthenticated limit is exhausted, `checkRateLimit()` slept until the reset time with no feedback, so "Scan Available Packs" just appeared frozen. I hit this during testing. Now fails fast with "try again in ~N minutes".

## Low

Assorted: `packScanInProgress` never cleared on two early-return paths (leaving the Scan button dead for the session); `window.CarrotKernel.showCarrotPopup` called where the shim only exposes `showPopup`; the pack-update toast calling a nonexistent `this.openPackManager()`; `$(document).one('keydown')` Escape handlers consumed by the first non-Escape key; a dead `writeExtensionField(extensionName, ...)` call (extension name in a character-id slot); potato-mode styling and the debug/clear-highlight buttons never being restored after `updatePanel()` wipes `innerHTML`; and `world_info_position` label tables missing `7: 'Outlet'`.

## Left alone

- `filterFromContext` / the `window.Generate` monkeypatch (`index.js:3278`) — the setting has no default and no writer, and `window.Generate` doesn't exist in staging, so the BunnyMoTags context filter is doubly dead. Deleting it vs. reimplementing it on a real hook felt like your call.
- Baby Bunny's "Finalize & Vectorize" flattens the edited chunks back to a string and hands it to `vectorizeFullsheetFromMessage`, which re-chunks from scratch — so custom keywords, weights, links and chunk boundaries from the chunking modal are discarded. Fixing it properly means inserting the edited chunks directly, which is a redesign rather than a patch.

---

## Testing

- Verified against SillyTavern staging `380e31e`; every claim above checked against the actual staging source rather than assumed.
- Loaded live alongside seven other extensions — no console errors on load, during generation, or across a swipe.
- Pack install exercised end-to-end against the live server: installs via `/api/worldinfo/edit`, lands under the expected clean filename (no `.json.json`), entries intact. Remote pack scan confirmed hitting the GitHub API and enumerating pack directories.
- `node --check` clean on all 11 modified files.
